### PR TITLE
Use same .NET SDK for local and CI builds via global.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Setup .NET Core SDK
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-        dotnet-quality: 'ga'
  
     - name: dotnet build
       run: dotnet build TodoApi.sln -c Release

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "7.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
The GitHub action `setup-dotnet` can read the SDK version from global.json: 
https://github.com/actions/setup-dotnet/blob/607fce577a46308457984d59e4954e075820f10a/action.yml#L9

By using global.json, the behavior between local execution and CI execution would be more consistent and the version doesn't have to be maintained in a quite hidden location.

PS: I dropped the "Core", because #dropthecore 😄 