### PR TITLE
Use launchSettings.json profile in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,9 +19,7 @@
                 "action": "openExternally",
                 "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
             },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
+            "launchSettingsProfile": "https",
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
             }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
                 "action": "openExternally",
                 "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
             },
-            "launchSettingsProfile": "https",
+            "launchSettingsProfile": "http",
             "sourceFileMap": {
                 "/Views": "${workspaceFolder}/Views"
             }


### PR DESCRIPTION
VS Code / Omnisharp supports using a profile from launchSettings.json

With this, people don't have to duplicate their environment variables and ports.

Details: https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#launchsettingsjson-support