### PR TITLE
Use DbContext Add rather than AddAsync method

### DIFF
--- a/TodoApi/TodoApi.cs
+++ b/TodoApi/TodoApi.cs
@@ -44,7 +44,7 @@ internal static class TodoApi
                 OwnerId = owner.Id
             };
 
-            await db.Todos.AddAsync(todo);
+            await db.Todos.Add(todo);
             await db.SaveChangesAsync();
 
             return Results.Created($"/todos/{todo.Id}", todo);

--- a/TodoApi/TodoApi.cs
+++ b/TodoApi/TodoApi.cs
@@ -44,7 +44,7 @@ internal static class TodoApi
                 OwnerId = owner.Id
             };
 
-            await db.Todos.Add(todo);
+            db.Todos.Add(todo);
             await db.SaveChangesAsync();
 
             return Results.Created($"/todos/{todo.Id}", todo);


### PR DESCRIPTION
The [EF docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.addasync?view=efcore-6.0#microsoft-entityframeworkcore-dbcontext-addasync(system-object-system-threading-cancellationtoken)) recommend using the non async `DbContext<TEntity>.Add` method when adding entities (except for special cases). This PR switches from the async method to the sync one.