### PR TITLE
Added RegEx client-side validation for Password

### DIFF
--- a/Todo.Web/Client/Components/LogInForm.razor
+++ b/Todo.Web/Client/Components/LogInForm.razor
@@ -27,7 +27,12 @@
     string? alertMessage;
 
     [Required, StringLength(15)] public string? Username { get; set; }
-    [Required, StringLength(32, MinimumLength = 6)] public string? Password { get; set; }
+
+    [Required, StringLength(32, MinimumLength = 6, ErrorMessage = "The password must be between 6 and 32 characters long.")]
+    [RegularExpression("^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z])(?=.*[^a-zA-Z\\d]).*$", 
+        MatchTimeoutInMilliseconds = 1000,
+        ErrorMessage = "The password must contain a lower-case letter, an upper-case letter, a digit and a special character.")]
+    public string? Password { get; set; }
 
     [Parameter] public EventCallback<string> OnLoggedIn { get; set; }
 


### PR DESCRIPTION
This fixes issue #39

The error message given when the RegEx fails isn't the nicest, since I don't know which part of it actually fails. To make it nicer, I believe I would have to use something like FluentValidation.