### PR TITLE
change the port from 8080 to 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run the application, run both the [Todo.Web/Server](Todo.Web/Server) and [Tod
       dotnet tool install --global Microsoft.Tye --version 0.11.0-alpha.22111.1
       ```
 
-      Run `tye run` in the repository root and navigate to the tye dashboard (usually http://localhost:8080) to see both applications running.
+      Run `tye run` in the repository root and navigate to the tye dashboard (usually http://localhost:8000) to see both applications running.
 
 
 ## Optional


### PR DESCRIPTION
In my case, after running this sample from tye, I find the tye dashboard is avaiable on http://127.0.0.1:8000/