### PR TITLE
Use automatic service registrations

### DIFF
--- a/TodoApi/Authentication/TokenService.cs
+++ b/TodoApi/Authentication/TokenService.cs
@@ -8,21 +8,13 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace TodoApi;
 
-public static class AuthenticationServiceExtensions
-{
-    public static IServiceCollection AddTokenService(this IServiceCollection services)
-    {
-        // Wire up the token service
-        return services.AddSingleton<ITokenService, TokenService>();
-    }
-}
-
 public interface ITokenService
 {
     // Generate a JWT token for the specified user name and admin role
     string GenerateToken(string username, bool isAdmin = false);
 }
 
+[Service(ServiceLifetime.Singleton)]
 public sealed class TokenService : ITokenService
 {
     private readonly string _issuer;

--- a/TodoApi/Authorization/CheckCurrentUserAuthHandler.cs
+++ b/TodoApi/Authorization/CheckCurrentUserAuthHandler.cs
@@ -4,12 +4,6 @@ namespace TodoApi;
 
 public static class AuthorizationHandlerExtensions
 {
-    public static AuthorizationBuilder AddCurrentUserHandler(this AuthorizationBuilder builder)
-    {
-        builder.Services.AddScoped<IAuthorizationHandler, CheckCurrentUserAuthHandler>();
-        return builder;
-    }
-
     // Adds the current user requirement that will activate our authorization handler
     public static AuthorizationPolicyBuilder RequireCurrentUser(this AuthorizationPolicyBuilder builder)
     {
@@ -17,11 +11,15 @@ public static class AuthorizationHandlerExtensions
                       .AddRequirements(new CheckCurrentUserRequirement());
     }
 
-    private class CheckCurrentUserRequirement : IAuthorizationRequirement { }
+    // NOTE: the source generator requires accessing these types. 
+    // In this particular case, we might still preserve the explicit invocation via
+    // an IServiceCollection extension method as before if keeping these types private is preferred.
+    internal class CheckCurrentUserRequirement : IAuthorizationRequirement { }
 
     // This authorization handler verifies that the user exists even if there's
     // a valid token
-    private class CheckCurrentUserAuthHandler : AuthorizationHandler<CheckCurrentUserRequirement>
+    [Service(ServiceLifetime.Scoped)]
+    internal class CheckCurrentUserAuthHandler : AuthorizationHandler<CheckCurrentUserRequirement>
     {
         private readonly CurrentUser _currentUser;
         public CheckCurrentUserAuthHandler(CurrentUser currentUser) => _currentUser = currentUser;

--- a/TodoApi/Authorization/CurrentUser.cs
+++ b/TodoApi/Authorization/CurrentUser.cs
@@ -3,6 +3,7 @@
 namespace TodoApi;
 
 // A scoped service that exposes the current user information
+[Service(ServiceLifetime.Scoped)]
 public class CurrentUser
 {
     public TodoUser? User { get; set; }

--- a/TodoApi/Authorization/CurrentUserExtensions.cs
+++ b/TodoApi/Authorization/CurrentUserExtensions.cs
@@ -1,43 +1,35 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
+using System.Security.Claims;
 
 namespace TodoApi;
 
-public static class CurrentUserExtensions
+// State that represents the current user from the database *and* the request
+[Service(ServiceLifetime.Scoped)]
+internal sealed class ClaimsTransformation : IClaimsTransformation
 {
-    public static IServiceCollection AddCurrentUser(this IServiceCollection services)
+    private readonly CurrentUser _currentUser;
+    private readonly UserManager<TodoUser> _userManager;
+
+    public ClaimsTransformation(CurrentUser currentUser, UserManager<TodoUser> userManager)
     {
-        services.AddScoped<CurrentUser>();
-        services.AddScoped<IClaimsTransformation, ClaimsTransformation>();
-        return services;
+        _currentUser = currentUser;
+        _userManager = userManager;
     }
 
-    private sealed class ClaimsTransformation : IClaimsTransformation
+    public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
     {
-        private readonly CurrentUser _currentUser;
-        private readonly UserManager<TodoUser> _userManager;
+        // We're not going to transform anything. We're using this as a hook into authorization
+        // to set the current user without adding custom middleware.
+        _currentUser.Principal = principal;
 
-        public ClaimsTransformation(CurrentUser currentUser, UserManager<TodoUser> userManager)
+        if (principal.FindFirstValue(ClaimTypes.NameIdentifier) is { Length: > 0 } name)
         {
-            _currentUser = currentUser;
-            _userManager = userManager;
+            // Resolve the user manager and see if the current user is a valid user in the database
+            // we do this once and store it on the current user.
+            _currentUser.User = await _userManager.FindByNameAsync(name);
         }
 
-        public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
-        {
-            // We're not going to transform anything. We're using this as a hook into authorization
-            // to set the current user without adding custom middleware.
-            _currentUser.Principal = principal;
-
-            if (principal.FindFirstValue(ClaimTypes.NameIdentifier) is { Length: > 0 } name)
-            {
-                // Resolve the user manager and see if the current user is a valid user in the database
-                // we do this once and store it on the current user.
-                _currentUser.User = await _userManager.FindByNameAsync(name);
-            }
-
-            return principal;
-        }
+        return principal;
     }
 }

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -6,10 +6,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configure auth
 builder.Services.AddAuthentication().AddJwtBearer();
-builder.Services.AddAuthorizationBuilder().AddCurrentUserHandler();
+builder.Services.AddAuthorization();
 
-// Add the service to generate JWT tokens
-builder.Services.AddTokenService();
+// Adds all services annotated with [Service(ServiceLifetime)]
+builder.Services.AddServices();
 
 // Configure the database
 var connectionString = builder.Configuration.GetConnectionString("Todos") ?? "Data Source=.db/Todos.db";
@@ -18,9 +18,6 @@ builder.Services.AddSqlite<TodoDbContext>(connectionString);
 // Configure identity
 builder.Services.AddIdentityCore<TodoUser>()
                 .AddEntityFrameworkStores<TodoDbContext>();
-
-// State that represents the current user from the database *and* the request
-builder.Services.AddCurrentUser();
 
 // Configure Open API
 builder.Services.AddEndpointsApiExplorer();

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection.Attributed" Version="1.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />


### PR DESCRIPTION
This showcases how to keep the minimalism by leveraging a source generator to emit all those pesky AddXXX calls to register services. The (compile-time) emitted source code is even more optimal than the previous one (no run-time lookup of a constructor). 

See https://github.com/devlooped/DependencyInjection.Attributed for reference. 

Perhaps that analyzer/source generator should be built-in ASP.NET?

BTW, since this adds "magic" that's not too visible to users, it might not be appropriate for the sample.