### PR TITLE
Fix postCreateCommand in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "extensions": [
     "ms-dotnettools.csharp"
   ],
-  "postCreateCommand": "init.sh",
+  "postCreateCommand": "chmod +x .devcontainer/init.sh && .devcontainer/init.sh",
   "forwardPorts": [
     5000,
     5001


### PR DESCRIPTION
The original value (`init.sh`) was not executing.
You can see this behavior in the Creation Log in your codespaces.