### PR TITLE
🖋️ Moved serilog configuration to configuration sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,4 @@ __pycache__/
 *.db-shm
 *.db-wal
 /.tye
+/.elastic-data

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Here are some examples about how to configure Elasticsearch and Kibana to work w
 📝 **`appsettings.json` Configuration source**
 ``` json
 "Serilog": {
-    "Using": [ "Serilog.Sinks.Seq" ],
+    "Using": [ "Serilog.Sinks.Elasticsearch" ],
     ...
     "WriteTo": [
         ...

--- a/README.md
+++ b/README.md
@@ -275,7 +275,6 @@ Here are some examples about how to configure Seq to work with the [Seq sink](ht
     ...
     "WriteTo": [
         ...
-        // REF: 
         {
             "Name": "Seq",
             "Args": {
@@ -308,7 +307,6 @@ Here are some examples about how to configure Elasticsearch and Kibana to work w
 "Serilog": {
     "Using": [ "Serilog.Sinks.Seq" ],
     ...
-    // Available Sinks (aka. Destinations to recieve logging data): 
     "WriteTo": [
         ...
         {

--- a/TodoApi/Extensions/SerilogExtensions.cs
+++ b/TodoApi/Extensions/SerilogExtensions.cs
@@ -1,5 +1,4 @@
 using Serilog;
-using Serilog.Exceptions;
 
 namespace TodoApi;
 
@@ -9,53 +8,15 @@ public static class SerilogExtensions
         this WebApplicationBuilder builder,
         string sectionName = "Serilog")
     {
-        var serilogOptions = new SerilogOptions();
-        builder.Configuration.GetSection(sectionName).Bind(serilogOptions);
-
         builder.Host.UseSerilog((context, loggerConfiguration) =>
         {
+            // Uncomment to debug serilog configuration source, startup errors.
+            //Serilog.Debugging.SelfLog.Enable(Console.Error);
+
             // https://github.com/serilog/serilog-settings-configuration
             loggerConfiguration.ReadFrom.Configuration(context.Configuration, sectionName: sectionName);
-
-            loggerConfiguration
-                .Enrich.WithProperty("Application", builder.Environment.ApplicationName)
-                .Enrich.FromLogContext()
-                // https://rehansaeed.com/logging-with-serilog-exceptions/
-                .Enrich.WithExceptionDetails();
-
-            if (serilogOptions.UseConsole)
-            {
-                // https://github.com/serilog/serilog-sinks-async
-                loggerConfiguration.WriteTo.Async(writeTo =>
-                    writeTo.Console(outputTemplate: serilogOptions.LogTemplate));
-            }
-
-            if (!string.IsNullOrEmpty(serilogOptions.ElasticSearchUrl))
-            {
-                // https://github.com/serilog-contrib/serilog-sinks-elasticsearch
-                loggerConfiguration.WriteTo.Elasticsearch(new(new Uri(serilogOptions.ElasticSearchUrl))
-                {
-                    AutoRegisterTemplate = true,
-                    IndexFormat = builder.Environment.ApplicationName
-                });
-            }
-
-            if (!string.IsNullOrEmpty(serilogOptions.SeqUrl))
-            {
-                loggerConfiguration.WriteTo.Seq(serilogOptions.SeqUrl);
-            }
         });
 
         return builder;
-    }
-
-    private sealed class SerilogOptions
-    {
-        public bool UseConsole { get; set; } = true;
-        public string? SeqUrl { get; set; }
-        public string? ElasticSearchUrl { get; set; }
-
-        public string LogTemplate { get; set; } =
-            "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level} - {Message:lj}{NewLine}{Exception}";
     }
 }

--- a/TodoApi/appsettings.Development.json
+++ b/TodoApi/appsettings.Development.json
@@ -1,24 +1,53 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Information",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.Seq", "Serilog.Sinks.Elasticsearch" ],
+        "Enrich": [ "FromLogContext", "WithExceptionDetails" ],
+        "MinimumLevel": {
+            "Override": {
+                "Microsoft": "Information"
+            }
+        },
+        // Available Sinks (aka. Destinations to recieve logging data): https://github.com/serilog/serilog/wiki/Provided-Sinks
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "OutputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level} - {Message:lj}{NewLine}{Exception}"
+                }
+            },
+            // REF: https://github.com/datalust/serilog-sinks-seq
+            {
+                "Name": "Seq",
+                "Args": {
+                    "serverUrl": "http://localhost:8081",
+                    "restrictedToMinimumLevel": "Information"
+                }
+            },
+            // REF: https://github.com/serilog-contrib/serilog-sinks-elasticsearch
+            {
+                "Name": "Elasticsearch",
+                "Args": {
+                    "NodeUris": "http://localhost:9200",
+                    "AutoRegisterTemplate": "true",
+                    "AutoRegisterTemplateVersion": "ESv7",
+                    "IndexFormat": "todoapi",
+                    "TypeName": null
+                }
+            }
+        ]
+    },
+
+    "Authentication": {
+        "Schemes": {
+            "Bearer": {
+                "ValidAudiences": [
+                    "http://localhost:47743",
+                    "https://localhost:44371",
+                    "http://localhost:5000",
+                    "https://localhost:5001"
+                ],
+                "ValidIssuer": "dotnet-user-jwts"
+            }
+        }
     }
-  },
-  "Authentication": {
-    "Schemes": {
-      "Bearer": {
-        "ValidAudiences": [
-          "http://localhost:47743",
-          "https://localhost:44371",
-          "http://localhost:5000",
-          "https://localhost:5001"
-        ],
-        "ValidIssuer": "dotnet-user-jwts"
-      }
-    }
-  }
 }

--- a/TodoApi/appsettings.Development.json
+++ b/TodoApi/appsettings.Development.json
@@ -1,7 +1,6 @@
 {
     "Serilog": {
         "Using": [ "Serilog.Sinks.Seq", "Serilog.Sinks.Elasticsearch" ],
-        "Enrich": [ "FromLogContext", "WithExceptionDetails" ],
         "MinimumLevel": {
             "Override": {
                 "Microsoft": "Information"

--- a/TodoApi/appsettings.Development.json
+++ b/TodoApi/appsettings.Development.json
@@ -1,36 +1,15 @@
 {
     "Serilog": {
-        "Using": [ "Serilog.Sinks.Seq", "Serilog.Sinks.Elasticsearch" ],
         "MinimumLevel": {
             "Override": {
                 "Microsoft": "Information"
             }
         },
-        // Available Sinks (aka. Destinations to recieve logging data): https://github.com/serilog/serilog/wiki/Provided-Sinks
         "WriteTo": [
             {
                 "Name": "Console",
                 "Args": {
                     "OutputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level} - {Message:lj}{NewLine}{Exception}"
-                }
-            },
-            // REF: https://github.com/datalust/serilog-sinks-seq
-            {
-                "Name": "Seq",
-                "Args": {
-                    "serverUrl": "http://localhost:8081",
-                    "restrictedToMinimumLevel": "Information"
-                }
-            },
-            // REF: https://github.com/serilog-contrib/serilog-sinks-elasticsearch
-            {
-                "Name": "Elasticsearch",
-                "Args": {
-                    "NodeUris": "http://localhost:9200",
-                    "AutoRegisterTemplate": "true",
-                    "AutoRegisterTemplateVersion": "ESv7",
-                    "IndexFormat": "todoapi",
-                    "TypeName": null
                 }
             }
         ]

--- a/TodoApi/appsettings.json
+++ b/TodoApi/appsettings.json
@@ -1,5 +1,9 @@
 {
     "Serilog": {
+        "Enrich": [ "FromLogContext", "WithExceptionDetails" ],
+        "Properties": {
+            "Application": "TodoApi"
+        },
         "MinimumLevel": {
             "Default": "Information",
             "Override": {

--- a/TodoApi/appsettings.json
+++ b/TodoApi/appsettings.json
@@ -1,12 +1,13 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
-    }
-  },
-  "AllowedHosts": "*"
+    "Serilog": {
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.Hosting.Lifetime": "Information"
+            }
+        }
+    },
+
+    "AllowedHosts": "*"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,30 +79,27 @@ services:
       - 8081:80
       - 5341:5341
     environment:
-      ACCEPT_EULA: Y
+      - ACCEPT_EULA=Y
 
   elasticsearch:
     container_name: elastic_search
     restart: on-failure
-    image: docker.elastic.co/elasticsearch/elasticsearch:latest
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
     environment:
+      - xpack.security.enabled=false
       - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - xpack.monitoring.enabled=true
-      - xpack.watcher.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1
         hard: -1
     volumes:
-      - elastic-data:/usr/share/elasticsearch/data
+      - ./.elastic-data:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
       - "9300:9300"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:latest
+    image: docker.elastic.co/kibana/kibana:8.5.3
     container_name: kibana
     restart: on-failure
     environment:


### PR DESCRIPTION
Resolves #60 

Okay - this leverages the `Serilog.Settings.Configuration` magic => we can config our sinks via configuration sources. Most obvious is the `appsettings.(env).json` file(s) , but of course we can now leverage secrets and environmental variables (think: Azure Configuration Settings and/or Docker Container Envs).

## 🔎 Changes

The main changes were:

- Remove any hardcoding from the `SerilogExtensions.cs` file.
- Add all settings to the either the `appsettings.json` or `appsettings.development.json`.

## 🕵🏻 Notes

Some interesting notes about how I've suggested things could be setup.

`appsettings.json` is the common file where the settings are shared/inherited for all environments. Notice this:

![image](https://user-images.githubusercontent.com/899878/209746797-f2a424a6-0064-4b42-8c17-f408542575f5.png)

1. The `enrichments` and `properties` will be used in _all_ environments. Set it once, use everywhere.
2. These are the "default" logging levels setup for _all_ environments. This is more of a "safety net". Usually one of these _might_ be over-written in the other `appsettings.development.json` or `appsettings.production.json` file(s). I really wanted to highlight that there's a base-default setting for logging .. which can be overwritten.

Notice how there's _NO_ sinks registered in the `appsettings.json` file? This is totally _by design_. A lot of the time, the settings for localhost-development / qa / production are different. Even the sinks _differ_ like .. localhost-development uses the `console` sink while production doesn't. Sometimes localhost-development uses Seq (it's free on local .. under the "individual" pricing tier) but for production uses some-other-logging-to-the-cloud.

Next, notice how the main `Serilog.AspNetCore` nuget has a transitive dependency for `Serilog.Settings.Configuration` ? 

![image](https://user-images.githubusercontent.com/899878/209747019-c734161e-e752-4aa9-82aa-57aa71ccc6bd.png)

This is why I haven't _manually_ added this nuget to the `.csproj`. ✅ 

## 💾 More on Sinks

One of the things with sinks are -> if you don't want it, just remove it from the config file. So if a developer doesn't want to log to ES, but only Seq, then they can just remove the ES child-section from the Serilog section.

Alternatively, they could also add their own sinks, here.

Lastly -> it's hard to figure out what's going on when sinks are logging correctly. Or not logging at all. 

This is why I have this comment in the code:

![image](https://user-images.githubusercontent.com/899878/209748108-4da7deb3-56e7-48cc-a6d5-4a134c8f854b.png)

This is magic. It dumps any errors (like bad errors when loading the config values). Here's an example I had (when this option was toggled to -> log errors to console):

![image](https://user-images.githubusercontent.com/899878/209748209-c4d8d5a2-8cf8-47cf-aa97-73ca621f33ee.png)

Notice that Capital-S? Yep. I had this in the config:

![image](https://user-images.githubusercontent.com/899878/209748274-3f26556b-d23b-4d54-8fca-873f808b7885.png)

and of course, the constructor is a Lowercase-S .. so my logging wasn't working (nothing was getting logged) .. and I had to turn on the `SelfLog` to determine that mistake.

## 🔥🔥 Pain points 🔥🔥

Elasticsearch. Zoh.Mai.Gawd. I've always had a hate-hate relationship with thee. With this PR, about 95% of my time was spent fighting with ES + Kibana. Firstly, the docker-compose file is busted and doesn't work. So I'll send _another_ PR for that, prior to this PR being accepted. But first, I just wanted to keep all eyes on this PR and to see if you like this concept, before I add more complexity with fixing up the docker-compose file.

But yeah -> I've always god damn hated ES/ ES+Kib. It's such a barrier to entry, when comparing it to other options (like Seq). Lots of tears 😢 have been shed.