### PR TITLE
Update OpenTelemetry registration

### DIFF
--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -29,7 +29,7 @@ public static class OpenTelemetryExtensions
             builder.Logging.AddOpenTelemetry(logging =>
             {
                 logging.SetResourceBuilder(resourceBuilder)
-                    .AddOtlpExporter();
+                       .AddOtlpExporter();
             });
         }
 
@@ -37,35 +37,34 @@ public static class OpenTelemetryExtensions
             .WithMetrics(metrics =>
             {
                 metrics.SetResourceBuilder(resourceBuilder)
-                    .AddPrometheusExporter()
-                    .AddAspNetCoreInstrumentation()
-                    .AddRuntimeInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddEventCountersInstrumentation(c =>
-                    {
-                        // https://learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters
-                        c.AddEventSources(
-                            "Microsoft.AspNetCore.Hosting",
-                            "Microsoft-AspNetCore-Server-Kestrel",
-                            "System.Net.Http",
-                            "System.Net.Sockets",
-                            "System.Net.NameResolution",
-                            "System.Net.Security");
-
-                    });
-            }).WithTracing(tracing =>
+                       .AddPrometheusExporter()
+                       .AddAspNetCoreInstrumentation()
+                       .AddRuntimeInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddEventCountersInstrumentation(c =>
+                       {
+                           // https://learn.microsoft.com/en-us/dotnet/core/diagnostics/available-counters
+                           c.AddEventSources(
+                               "Microsoft.AspNetCore.Hosting",
+                               "Microsoft-AspNetCore-Server-Kestrel",
+                               "System.Net.Http",
+                               "System.Net.Sockets",
+                               "System.Net.NameResolution",
+                               "System.Net.Security");
+                       });
+            })
+            .WithTracing(tracing =>
             {
                 tracing.SetResourceBuilder(resourceBuilder)
-                    .AddAspNetCoreInstrumentation()
-                    .AddHttpClientInstrumentation()
-                    .AddEntityFrameworkCoreInstrumentation();
+                       .AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddEntityFrameworkCoreInstrumentation();
 
                 if (!string.IsNullOrWhiteSpace(otlpEndpoint))
                 {
                     tracing.AddOtlpExporter();
 
                 }
-
             });
 
         return builder;

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -65,7 +65,8 @@ public static class OpenTelemetryExtensions
                     tracing.AddOtlpExporter();
 
                 }
-            });
+            })
+            .StartWithHost();
 
         return builder;
     }

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -20,16 +20,16 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0-rc.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.0.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.0.0-alpha.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.0.0-alpha.5" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-beta.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The way we're currently registrering OpenTelemetry is obsolete, so I've updated to `1.4.0-rc.3` and migrated to the recommended registration method.