### PR TITLE
Bug fix: The AddOpenApiSecurityRequirement creates empty requestBody …

### DIFF
--- a/TodoApi/Extensions/OpenApiExtensions.cs
+++ b/TodoApi/Extensions/OpenApiExtensions.cs
@@ -28,8 +28,7 @@ public static class OpenApiExtensions
                 {
                     [scheme] = new List<string>()
                 }
-            },
-            RequestBody = operation.RequestBody
+            }
         });
     }
 

--- a/TodoApi/Extensions/OpenApiExtensions.cs
+++ b/TodoApi/Extensions/OpenApiExtensions.cs
@@ -28,7 +28,8 @@ public static class OpenApiExtensions
                 {
                     [scheme] = new List<string>()
                 }
-            }
+            },
+            RequestBody = operation.RequestBody
         });
     }
 

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -14,8 +14,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
-	<PackageReference Include="Microsoft.OpenApi" Version="1.6.4-preview2" />
-	<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.4-preview2" />
+    <PackageReference Include="MiniValidation" Version="0.6.0-pre.20220527.55" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
+	<PackageReference Include="Microsoft.OpenApi" Version="1.6.4-preview2" />
     <PackageReference Include="MiniValidation" Version="0.6.0-pre.20220527.55" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -15,8 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
 	<PackageReference Include="Microsoft.OpenApi" Version="1.6.4-preview2" />
-    <PackageReference Include="MiniValidation" Version="0.6.0-pre.20220527.55" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+	<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   


### PR DESCRIPTION
…when it originaly should be left null. This messes up operations in the openapi spec that otherwise have an empty body.

I cannot help but wonder though if the `new OpenApiOperation` constructor should be taking the liberty of initializing the RequestBody property since the passed parameter has it null. Maybe it is a bug with the `Microsoft.AspNetCore.OpenApi` library. 

I love this repo and was deeply influenced to start with minimal APIs (and docker for that matter). So my pull request is for all the people like me that copied the helpers (Extensions) from here as a starting point. 

This is not related to the endpoints behavior but can be a problem when you are actually invested in generating clients from the open API spec.