### PR TITLE
Fix OpenTelemetry Trace Recording

### DIFF
--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -1,4 +1,4 @@
-﻿         using OpenTelemetry;
+﻿using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -29,7 +29,7 @@ public static class OpenTelemetryExtensions
             builder.Logging.AddOpenTelemetry(logging =>
             {
                 logging.SetResourceBuilder(resourceBuilder)
-                       .AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
+                        .AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
             });
         }
 
@@ -55,6 +55,9 @@ public static class OpenTelemetryExtensions
             })
             .WithTracing(tracing =>
             {
+                //we need to use AlwaysSampler to record spans
+                //from Todo.Web.Server, because there it no opentelemetry
+                //instrumentation
                 tracing.SetResourceBuilder(resourceBuilder)
                         .SetSampler(new AlwaysOnSampler())
                        .AddAspNetCoreInstrumentation()

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -29,7 +29,7 @@ public static class OpenTelemetryExtensions
             builder.Logging.AddOpenTelemetry(logging =>
             {
                 logging.SetResourceBuilder(resourceBuilder)
-                        .AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
+                        .AddOtlpExporter();
             });
         }
 
@@ -66,7 +66,7 @@ public static class OpenTelemetryExtensions
 
                 if (!string.IsNullOrWhiteSpace(otlpEndpoint))
                 {
-                    tracing.AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
+                    tracing.AddOtlpExporter();
                 }
             })
             .StartWithHost();

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -29,7 +29,7 @@ public static class OpenTelemetryExtensions
             builder.Logging.AddOpenTelemetry(logging =>
             {
                 logging.SetResourceBuilder(resourceBuilder)
-                        .AddOtlpExporter();
+                       .AddOtlpExporter();
             });
         }
 

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using OpenTelemetry;
+﻿         using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -29,7 +29,7 @@ public static class OpenTelemetryExtensions
             builder.Logging.AddOpenTelemetry(logging =>
             {
                 logging.SetResourceBuilder(resourceBuilder)
-                       .AddOtlpExporter();
+                       .AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
             });
         }
 
@@ -56,14 +56,14 @@ public static class OpenTelemetryExtensions
             .WithTracing(tracing =>
             {
                 tracing.SetResourceBuilder(resourceBuilder)
+                        .SetSampler(new AlwaysOnSampler())
                        .AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddEntityFrameworkCoreInstrumentation();
 
                 if (!string.IsNullOrWhiteSpace(otlpEndpoint))
                 {
-                    tracing.AddOtlpExporter();
-
+                    tracing.AddOtlpExporter(c => c.Endpoint = new Uri(otlpEndpoint));
                 }
             })
             .StartWithHost();

--- a/TodoApi/Extensions/OpenTelemetryExtensions.cs
+++ b/TodoApi/Extensions/OpenTelemetryExtensions.cs
@@ -55,11 +55,11 @@ public static class OpenTelemetryExtensions
             })
             .WithTracing(tracing =>
             {
-                //we need to use AlwaysSampler to record spans
-                //from Todo.Web.Server, because there it no opentelemetry
-                //instrumentation
+                // We need to use AlwaysSampler to record spans
+                // from Todo.Web.Server, because there it no OpenTelemetry
+                // instrumentation
                 tracing.SetResourceBuilder(resourceBuilder)
-                        .SetSampler(new AlwaysOnSampler())
+                       .SetSampler(new AlwaysOnSampler())
                        .AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddEntityFrameworkCoreInstrumentation();


### PR DESCRIPTION
David, thank you for a greate app. I've played with it locally and found out, that when you use the app and enable distributed tracing collection, you don't see the requests in jaeger. 
 
To make opentelemetry instrumentation to record spans when we use the app, we need to add `AlwaysOnSampler`.

See https://github.com/open-telemetry/opentelemetry-dotnet/issues/4074.