### PR TITLE
Rename AuthenticatonSchemes to AuthenticationSchemes

### DIFF
--- a/Todo.Web/Server/AuthApi.cs
+++ b/Todo.Web/Server/AuthApi.cs
@@ -63,7 +63,7 @@ public static class AuthApi
         group.MapGet("signin/{provider}", async (string provider, AuthClient client, HttpContext context) =>
         {
             // Grab the login information from the external login dance
-            var result = await context.AuthenticateAsync(AuthenticatonSchemes.ExternalScheme);
+            var result = await context.AuthenticateAsync(AuthenticationSchemes.ExternalScheme);
 
             if (result.Succeeded)
             {
@@ -85,7 +85,7 @@ public static class AuthApi
             }
 
             // Delete the external cookie
-            await context.SignOutAsync(AuthenticatonSchemes.ExternalScheme);
+            await context.SignOutAsync(AuthenticationSchemes.ExternalScheme);
 
             // TODO: Handle the failure somehow
 

--- a/Todo.Web/Server/Authentication/AuthenticationExtensions.cs
+++ b/Todo.Web/Server/Authentication/AuthenticationExtensions.cs
@@ -19,7 +19,7 @@ public static class AuthenticationExtensions
         authenticationBuilder.AddCookie();
 
         // This is the cookie that will store the user information from the external login provider
-        authenticationBuilder.AddCookie(AuthenticatonSchemes.ExternalScheme);
+        authenticationBuilder.AddCookie(AuthenticationSchemes.ExternalScheme);
 
         // Add external auth providers based on configuration
         //{
@@ -59,7 +59,7 @@ public static class AuthenticationExtensions
                     // This will save the information in the external cookie
                     if (options is RemoteAuthenticationOptions remoteAuthenticationOptions)
                     {
-                        remoteAuthenticationOptions.SignInScheme = AuthenticatonSchemes.ExternalScheme;
+                        remoteAuthenticationOptions.SignInScheme = AuthenticationSchemes.ExternalScheme;
                     }
                     else if (options is Auth0WebAppOptions auth0WebAppOptions)
                     {
@@ -88,7 +88,7 @@ public static class AuthenticationExtensions
                 {
                     // The Auth0 APIs don't let you set the sign in scheme, it defaults to the default sign in scheme.
                     // Use named options to configure the underlying OpenIdConnectOptions's sign in scheme instead.
-                    o.SignInScheme = AuthenticatonSchemes.ExternalScheme;
+                    o.SignInScheme = AuthenticationSchemes.ExternalScheme;
                 });
         }
     }

--- a/Todo.Web/Server/Authentication/AuthenticationSchemes.cs
+++ b/Todo.Web/Server/Authentication/AuthenticationSchemes.cs
@@ -1,6 +1,6 @@
 ﻿namespace Todo.Web.Server;
 
-public class AuthenticatonSchemes
+public class AuthenticationSchemes
 {
     // This is the scheme used to store login information from external providers
     public static string ExternalScheme => "External";

--- a/Todo.Web/Server/Authentication/ExternalProviders.cs
+++ b/Todo.Web/Server/Authentication/ExternalProviders.cs
@@ -28,7 +28,7 @@ public class ExternalProviders
         {
             // We're assuming all schemes that aren't cookies are social
             if (s.Name == CookieAuthenticationDefaults.AuthenticationScheme ||
-                s.Name == AuthenticatonSchemes.ExternalScheme)
+                s.Name == AuthenticationSchemes.ExternalScheme)
             {
                 continue;
             }


### PR DESCRIPTION
* Fixes a Typo `AuthenticatonSchemes` to `AuthenticationSchemes`